### PR TITLE
Add controlled compilation of theme mix .dll on mix saving.

### DIFF
--- a/ThemeMixer/Serialization/SerializationService.cs
+++ b/ThemeMixer/Serialization/SerializationService.cs
@@ -261,6 +261,11 @@ namespace ThemeMixer.Serialization
             if (!Data.DisableCompile) CreateSourceCode(mixModSourceDir, mixNameTypeSafe, mixName);
             CreateUsedAssetsFile(mix, mixDir);
             SaveXmlFile(mix, mixDir);
+
+            // Force manual compilation of source at controlled time.
+            // Only specify ICities.dll as additional assembly to avoid 'file not found' errors with m_additionalAssembly empty strings.
+            PluginManager.CompileSourceInFolder(mixModSourceDir, mixDir, new string[] { typeof(ICities.IUserMod).Assembly.Location });
+
             LoadAvailableMixes();
         }
 


### PR DESCRIPTION
The patch to disable automatic compilation of added mods while the game is running should be maintained, and this will enable the mod to control the timing and parameters of the .dll compilation.

This will enable the .dll to be compiled by the mod at the time of mix saving instead of having to wait for a restart of the game, and controlling the timing and the parameters should avoid the compilation errors encountered by some users.