### PR TITLE
Delete theme mod source after compile.

### DIFF
--- a/ThemeMixer/Serialization/SerializationService.cs
+++ b/ThemeMixer/Serialization/SerializationService.cs
@@ -266,6 +266,10 @@ namespace ThemeMixer.Serialization
             // Only specify ICities.dll as additional assembly to avoid 'file not found' errors with m_additionalAssembly empty strings.
             PluginManager.CompileSourceInFolder(mixModSourceDir, mixDir, new string[] { typeof(ICities.IUserMod).Assembly.Location });
 
+            // Delete source once we've compiled; this prevents redundant (and error-prone) re-compiliation attempts on future game loads.
+            Debug.Log("Theme Mixer: deleting source files at " + mixModSourceDir);
+            Directory.Delete(mixModSourceDir, true);
+
             LoadAvailableMixes();
         }
 


### PR DESCRIPTION
Taking advantage of the new managed compilation process, this change removes the source files as soon as compilation completes. This will prevent future re-compilation attempts, which are both unnecessary and can trigger errors.